### PR TITLE
Updated all dependencies and fixed the Keyberon dep inside Cargo.toml

### DIFF
--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -70,32 +70,11 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rt"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d8353767db816419630a76d5f1ad5b09610d22b67ceb59647df6a8abc667f8"
-dependencies = [
- "cortex-m-rt-macros 0.1.8",
- "r0",
-]
-
-[[package]]
-name = "cortex-m-rt"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069533b58e25b635fac881eb6556616bd8f83a3e0ffe2b4b9619289ed14d465e"
 dependencies = [
- "cortex-m-rt-macros 0.7.0",
-]
-
-[[package]]
-name = "cortex-m-rt-macros"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4717562afbba06e760d34451919f5c3bf3ac15c7bb897e8b04862a7428378647"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "cortex-m-rt-macros",
 ]
 
 [[package]]
@@ -243,6 +222,7 @@ dependencies = [
 [[package]]
 name = "keyberon"
 version = "0.2.0"
+source = "git+https://github.com/TeXitoi/keyberon#23deef5d6330c3167025a1f4aeccdc44e3d44ec1"
 dependencies = [
  "arraydeque",
  "either",
@@ -255,6 +235,7 @@ dependencies = [
 [[package]]
 name = "keyberon-macros"
 version = "0.1.0"
+source = "git+https://github.com/TeXitoi/keyberon#23deef5d6330c3167025a1f4aeccdc44e3d44ec1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -386,7 +367,7 @@ name = "pinci"
 version = "0.1.0"
 dependencies = [
  "cortex-m",
- "cortex-m-rt 0.6.14",
+ "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal",
  "embedded-time",
@@ -452,12 +433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r0"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
-
-[[package]]
 name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,9 +440,9 @@ checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 
 [[package]]
 name = "rp2040-boot2"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233203dcc51018ec08df8462fc84c0170aa4b4220bbcbe56901bc637ba98604a"
+checksum = "8b480fe63133f0d639f82ce5a027fee7cac7ac92f67ef1896ee036a6f9737128"
 dependencies = [
  "crc-any",
 ]
@@ -498,7 +473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b6e222c239e9f08d36faf5e2372b4eb0661b3535e3b28942db1e937a9d15f76"
 dependencies = [
  "cortex-m",
- "cortex-m-rt 0.7.0",
+ "cortex-m-rt",
  "vcell",
 ]
 

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2018"
 
 [dependencies]
 cortex-m = "0.7.2"
-cortex-m-rt = { version = "0.6.14", features = ["device"] }
+cortex-m-rt = { version = "0.7", features = ["device"] }
 cortex-m-rtic = "0.6.0-rc.1"
 embedded-time = "0.12.0"
 usb-device= "0.2.8"
 usbd-serial = "0.1.1"
 usbd-hid = "0.5.0"
-keyberon = { path = "./../../keyberon" }
+keyberon = { git = "https://github.com/TeXitoi/keyberon" }
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 rp2040-hal = { git = "https://github.com/rp-rs/rp-hal", rev = "77787e760d08a33b558879b239cd28e65c2e369d", features = ["rt"] }
-rp2040-boot2 = "0.1.2"
+rp2040-boot2 = "0.2.0"
 

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -6,7 +6,7 @@ use rp2040_hal as hal;
 
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
 
 #[rtic::app(device = crate::hal::pac, peripherals = true, dispatchers = [PIO0_IRQ_0])]
 mod app {
@@ -46,10 +46,10 @@ mod app {
     const UF2: Action<CustomActions> = Action::Custom(CustomActions::Uf2);
     const RESET: Action<CustomActions> = Action::Custom(CustomActions::Reset);
 
-    const QW_ESC: ChordDef = ChordDef::new((0, 37), &[(0, 0), (0, 1)]);
-    const JU_ESC: ChordDef = ChordDef::new((0, 37), &[(0, 16), (0, 6)]);
-    const KI_TAB: ChordDef = ChordDef::new((0, 39), &[(0, 17), (0, 7)]);
-    const LO_ENTER: ChordDef = ChordDef::new((0, 38), &[(0, 18), (0, 8)]);
+    const QW_ESC: ChordDef = ((0, 37), &[(0, 0), (0, 1)]);
+    const JU_ESC: ChordDef = ((0, 37), &[(0, 16), (0, 6)]);
+    const KI_TAB: ChordDef = ((0, 39), &[(0, 17), (0, 7)]);
+    const LO_ENTER: ChordDef = ((0, 38), &[(0, 18), (0, 8)]);
     const CHORDS: [ChordDef; 4] = [QW_ESC, JU_ESC, KI_TAB, LO_ENTER];
 
     const A_LSHIFT: Action<CustomActions> = Action::HoldTap {
@@ -143,7 +143,7 @@ pub static LAYERS: keyberon::layout::Layers<CustomActions> = keyberon::layout::l
         Q W E R T Y U I O P
         {A_LSHIFT} {L5_S} {D_LALT} {L2_F} G H J K L {SEMI_RSHIFT}
         {Z_LCTRL} {X_LALT} {L4_C} V B N M {L4_COMMA} {DOT_RALT} {SLASH_RCTRL}
-        t t t (3) BSpace {L7_SPACE} Tab Escape Enter Tab 
+        t t t (3) BSpace {L7_SPACE} Tab Escape Enter Tab
     ]}
     {[ // 1
         t t t t t t t t t t
@@ -203,7 +203,7 @@ pub static LAYERS: keyberon::layout::Layers<CustomActions> = keyberon::layout::l
         #[lock_free]
         watchdog: hal::watchdog::Watchdog,
         #[lock_free]
-        chording: Chording,
+        chording: Chording<4>,
         #[lock_free]
         matrix: Matrix<DynPin, DynPin, 17, 1>,
         layout: Layout<CustomActions>,


### PR DESCRIPTION
All dependencies have been updated to their latest versions and the path to Keyberon was fixed inside Cargo.toml so it points to the github repo (which is necessary to build it because the stable release doesn't have chording yet).  In order to do that I had to make a few trivial changes to the code since it didn't quite match how the new chording feature wants you to define things and there were some minor changes to rp2040-boot2 in 0.2.0 which changed how you're supposed to use it (slightly).

I tested that these changes compile and flash to an rp2040 board (an ItsyBitsy which is basically just a smaller version of the main Pico board) but I did not test using it as an actual keyboard.  It should work just fine though 👍